### PR TITLE
PHP deprecation error in WP_Image_Editor crop (`Implicit conversion from float)

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -725,7 +725,7 @@ function image_edit_apply_changes( $image, $changes ) {
 					$h    = $size['height'];
 
 					$scale = 1 / _image_get_preview_ratio( $w, $h ); // Discard preview scaling.
-					$image->crop( $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );
+					$image->crop( (int) ( $sel->x * $scale ), (int) ( $sel->y * $scale ), (int) ( $sel->w * $scale ), (int) ( $sel->h * $scale ) );
 				} else {
 					$scale = 1 / _image_get_preview_ratio( imagesx( $image ), imagesy( $image ) ); // Discard preview scaling.
 					$image = _crop_image_resource( $image, $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -540,10 +540,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				case 'crop':
 					$size = $image_editor->get_size();
 
-					$crop_x = round( ( $size['width'] * $args['left'] ) / 100.0 );
-					$crop_y = round( ( $size['height'] * $args['top'] ) / 100.0 );
-					$width  = round( ( $size['width'] * $args['width'] ) / 100.0 );
-					$height = round( ( $size['height'] * $args['height'] ) / 100.0 );
+					$crop_x = (int) round( ( $size['width'] * $args['left'] ) / 100.0 );
+					$crop_y = (int) round( ( $size['height'] * $args['top'] ) / 100.0 );
+					$width  = (int) round( ( $size['width'] * $args['width'] ) / 100.0 );
+					$height = (int) round( ( $size['height'] * $args['height'] ) / 100.0 );
 
 					if ( $size['width'] !== $width && $size['height'] !== $height ) {
 						$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2138,7 +2138,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertCount( 1, WP_Image_Editor_Mock::$spy['crop'] );
 		$this->assertSame(
-			array( 320.0, 48.0, 64.0, 24.0 ),
+			array( 320, 48, 64, 24 ),
 			WP_Image_Editor_Mock::$spy['crop'][0]
 		);
 	}


### PR DESCRIPTION
This pull request removes the PHP deprecated errors (like `Implicit conversion from float 1112.7466666666667 to int loses precision`) in `WP_Image_Editor_Imagick`/`WP_Image_Editor` `crop` method.

While `crop` expects integers, integers are not always passed to it.
So the goal is to cast the params to cast `(int)` **before** passing them to the method.

Other usage of `crop` already have `int` params so only 2 occurrences were fixed.

**Tested on:**
- PHP 8.1
- PHP 8.0

**How to reproduce the error:**
1. Go to /wp-admin/media-new.php and upload an image
2. "Edit" the image
3. Then do a crop with the mouse and "Apply crop"
4. See the `Implicit conversion from float` in the debug log

**Trac ticket:** 
https://core.trac.wordpress.org/ticket/59782
